### PR TITLE
Quick fix to a persistent problem

### DIFF
--- a/a10_openstack_lib/resources/a10_certificate.py
+++ b/a10_openstack_lib/resources/a10_certificate.py
@@ -172,6 +172,3 @@ VALIDATORS = {
     'a10_type:reference': lambda validators: validate_reference,
     'a10_type:nullable': validate_nullable
 }
-
-
-

--- a/a10_openstack_lib/resources/a10_device_instance.py
+++ b/a10_openstack_lib/resources/a10_device_instance.py
@@ -125,8 +125,9 @@ def convert_to_lower(input):
     except AttributeError:
         return input
 
+
 def convert_to_int(input):
     try:
         return int(input)
     except (ValueError, TypeError):
-        msg = _("'%s' is not an integer") % input
+        pass

--- a/a10_openstack_lib/resources/a10_device_instance.py
+++ b/a10_openstack_lib/resources/a10_device_instance.py
@@ -102,7 +102,7 @@ RESOURCE_ATTRIBUTE_MAP = {
             'validate': {
                 'type:range': [0, 65535]
             },
-            'convert_to': lambda attr: attr.convert_to_int,
+            'convert_to': lambda attr: convert_to_int,
             'is_visible': True,
             'default': lambda attr: attr.ATTR_NOT_SPECIFIED
         },
@@ -122,5 +122,11 @@ RESOURCE_ATTRIBUTE_MAP = {
 def convert_to_lower(input):
     try:
         return input.lower()
+    except AttributeError:
+        return input
+
+def convert_to_int(input):
+    try:
+        return int(input)
     except AttributeError:
         return input

--- a/a10_openstack_lib/resources/a10_device_instance.py
+++ b/a10_openstack_lib/resources/a10_device_instance.py
@@ -128,5 +128,5 @@ def convert_to_lower(input):
 def convert_to_int(input):
     try:
         return int(input)
-    except AttributeError:
-        return input
+    except (ValueError, TypeError):
+        msg = _("'%s' is not an integer") % input


### PR DESCRIPTION
From my understanding, changes in neutron have broken the functionality of the template. I mimicked what was done with "conver_to_lower" and localized the functionality of "convert_to_int" present in the neutron-lib api. This fixes the issue and provides the exact same functionality as what is present in the neturon-lib api.